### PR TITLE
fix(database-mysql): mysql8 auth, use driver 'mysql2'

### DIFF
--- a/packages/database-mysql/README.md
+++ b/packages/database-mysql/README.md
@@ -11,10 +11,10 @@ Synor Database Engine - MySQL
 
 ```sh
 # using yarn:
-yarn add @synor/database-mysql mysql
+yarn add @synor/database-mysql mysql2
 
 # using npm:
-npm install --save @synor/database-mysql mysql
+npm install --save @synor/database-mysql mysql2
 ```
 
 ## URI

--- a/packages/database-mysql/docker-compose.test.yml
+++ b/packages/database-mysql/docker-compose.test.yml
@@ -9,4 +9,12 @@ services:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: synor
     ports:
-      - 3306:3306
+      - 33065:3306
+  mysql8:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: synor
+    ports:
+      - 33068:3306

--- a/packages/database-mysql/jest.env.js
+++ b/packages/database-mysql/jest.env.js
@@ -1,5 +1,5 @@
 const NodeEnvironment = require('jest-environment-node')
-const { createConnection } = require('mysql')
+const { createConnection } = require('mysql2')
 
 const uri = 'mysql://root:root@127.0.0.1:3306/synor'
 

--- a/packages/database-mysql/package.json
+++ b/packages/database-mysql/package.json
@@ -37,12 +37,11 @@
   },
   "devDependencies": {
     "@synor/core": "^0.10.1",
-    "@types/mysql": "^2",
-    "mysql": "^2"
+    "mysql2": "^2"
   },
   "peerDependencies": {
     "@synor/core": "^0.9.0",
-    "mysql": "^2"
+    "mysql2": "^2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/database-mysql/src/__snapshots__/index.test.ts.snap
+++ b/packages/database-mysql/src/__snapshots__/index.test.ts.snap
@@ -40,7 +40,7 @@ Array [
 
 exports[`methods repair 1`] = `
 Array [
-  RowDataPacket {
+  Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
     "applied_by": "Synor",
     "dirty": 0,
@@ -51,7 +51,7 @@ Array [
     "type": "do",
     "version": "0",
   },
-  RowDataPacket {
+  Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
     "applied_by": "Jest",
     "dirty": 0,
@@ -67,7 +67,7 @@ Array [
 
 exports[`methods run (with body) 1`] = `
 Array [
-  RowDataPacket {
+  Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
     "applied_by": "Synor",
     "dirty": 0,
@@ -78,7 +78,7 @@ Array [
     "type": "do",
     "version": "0",
   },
-  RowDataPacket {
+  Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
     "applied_by": "Jest",
     "dirty": 0,
@@ -89,7 +89,7 @@ Array [
     "type": "do",
     "version": "01",
   },
-  RowDataPacket {
+  Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
     "applied_by": "Jest",
     "dirty": 1,
@@ -105,7 +105,7 @@ Array [
 
 exports[`methods run (with run) 1`] = `
 Array [
-  RowDataPacket {
+  Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
     "applied_by": "Synor",
     "dirty": 0,
@@ -116,7 +116,7 @@ Array [
     "type": "do",
     "version": "0",
   },
-  RowDataPacket {
+  Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
     "applied_by": "Jest",
     "dirty": 0,

--- a/packages/database-mysql/src/__snapshots__/index.test.ts.snap
+++ b/packages/database-mysql/src/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`methods records 1`] = `
+exports[`mysql5 methods records 1`] = `
 Array [
   Object {
     "appliedAt": 2020-01-01T00:00:00.000Z,
@@ -38,7 +38,7 @@ Array [
 ]
 `;
 
-exports[`methods repair 1`] = `
+exports[`mysql5 methods repair 1`] = `
 Array [
   Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
@@ -65,7 +65,7 @@ Array [
 ]
 `;
 
-exports[`methods run (with body) 1`] = `
+exports[`mysql5 methods run (with body) 1`] = `
 Array [
   Object {
     "applied_at": 2020-01-01T00:00:00.000Z,
@@ -103,7 +103,137 @@ Array [
 ]
 `;
 
-exports[`methods run (with run) 1`] = `
+exports[`mysql5 methods run (with run) 1`] = `
+Array [
+  Object {
+    "applied_at": 2020-01-01T00:00:00.000Z,
+    "applied_by": "Synor",
+    "dirty": 0,
+    "execution_time": 0,
+    "hash": "",
+    "id": 1,
+    "title": "Base Migration",
+    "type": "do",
+    "version": "0",
+  },
+  Object {
+    "applied_at": 2020-01-01T00:00:00.000Z,
+    "applied_by": "Jest",
+    "dirty": 0,
+    "execution_time": 0,
+    "hash": "hash-02-do",
+    "id": 2,
+    "title": "Test Two",
+    "type": "do",
+    "version": "02",
+  },
+]
+`;
+
+exports[`mysql8 methods records 1`] = `
+Array [
+  Object {
+    "appliedAt": 2020-01-01T00:00:00.000Z,
+    "appliedBy": "Synor",
+    "dirty": false,
+    "executionTime": 0,
+    "hash": "",
+    "id": 1,
+    "title": "Base Migration",
+    "type": "do",
+    "version": "0",
+  },
+  Object {
+    "appliedAt": 2020-01-01T00:00:00.000Z,
+    "appliedBy": "Jest",
+    "dirty": false,
+    "executionTime": 0,
+    "hash": "hash-01-do",
+    "id": 2,
+    "title": "Test One",
+    "type": "do",
+    "version": "01",
+  },
+  Object {
+    "appliedAt": 2020-01-01T00:00:00.000Z,
+    "appliedBy": "Jest",
+    "dirty": true,
+    "executionTime": 0,
+    "hash": "hash-01-undo",
+    "id": 3,
+    "title": "Test One",
+    "type": "undo",
+    "version": "01",
+  },
+]
+`;
+
+exports[`mysql8 methods repair 1`] = `
+Array [
+  Object {
+    "applied_at": 2020-01-01T00:00:00.000Z,
+    "applied_by": "Synor",
+    "dirty": 0,
+    "execution_time": 0,
+    "hash": "",
+    "id": 1,
+    "title": "Base Migration",
+    "type": "do",
+    "version": "0",
+  },
+  Object {
+    "applied_at": 2020-01-01T00:00:00.000Z,
+    "applied_by": "Jest",
+    "dirty": 0,
+    "execution_time": 0,
+    "hash": "hash-01-do-repaired",
+    "id": 2,
+    "title": "Test One",
+    "type": "do",
+    "version": "01",
+  },
+]
+`;
+
+exports[`mysql8 methods run (with body) 1`] = `
+Array [
+  Object {
+    "applied_at": 2020-01-01T00:00:00.000Z,
+    "applied_by": "Synor",
+    "dirty": 0,
+    "execution_time": 0,
+    "hash": "",
+    "id": 1,
+    "title": "Base Migration",
+    "type": "do",
+    "version": "0",
+  },
+  Object {
+    "applied_at": 2020-01-01T00:00:00.000Z,
+    "applied_by": "Jest",
+    "dirty": 0,
+    "execution_time": 0,
+    "hash": "hash-01-do",
+    "id": 2,
+    "title": "Test One",
+    "type": "do",
+    "version": "01",
+  },
+  Object {
+    "applied_at": 2020-01-01T00:00:00.000Z,
+    "applied_by": "Jest",
+    "dirty": 1,
+    "execution_time": 0,
+    "hash": "hash-01-undo",
+    "id": 3,
+    "title": "Test One",
+    "type": "undo",
+    "version": "01",
+  },
+]
+`;
+
+exports[`mysql8 methods run (with run) 1`] = `
 Array [
   Object {
     "applied_at": 2020-01-01T00:00:00.000Z,

--- a/packages/database-mysql/src/index.test.ts
+++ b/packages/database-mysql/src/index.test.ts
@@ -1,8 +1,9 @@
-import { createConnection } from 'mysql'
+import { createConnection } from 'mysql2'
 import MySQLEngine, { MySQLDatabaseEngine } from './index'
+import { getConfig } from './utils/get-config'
 import { runQuery } from './utils/run-query'
 
-type Connection = import('mysql').Connection
+type Connection = import('mysql2').Connection
 
 type GetAdvisoryLockId = import('@synor/core').GetAdvisoryLockId
 type GetUserInfo = import('@synor/core').GetUserInfo
@@ -143,7 +144,9 @@ describe('methods: {open,close}', () => {
   let engine: ReturnType<typeof MySQLDatabaseEngine>
 
   beforeAll(async () => {
-    connection = createConnection(uri)
+    const { databaseConfig } = getConfig(uri)
+
+    connection = createConnection(databaseConfig)
 
     await runQuery(connection, 'DROP TABLE IF EXISTS ??;', [tableName])
   })
@@ -306,7 +309,9 @@ describe('methods', () => {
       }
     } as typeof global.Date
 
-    connection = createConnection(uri)
+    const { databaseConfig } = getConfig(uri)
+
+    connection = createConnection(databaseConfig)
 
     await runQuery(connection, 'DROP TABLE IF EXISTS ??;', [tableName])
   })

--- a/packages/database-mysql/src/index.test.ts
+++ b/packages/database-mysql/src/index.test.ts
@@ -66,7 +66,10 @@ const getUserInfo: GetUserInfo = () => Promise.resolve(`Jest`)
 const databaseName = 'synor'
 const tableName = 'test_record'
 const params = `synor_migration_record_table=${tableName}`
-const uri = `mysql://root:root@127.0.0.1:3306/${databaseName}?${params}`
+const uris = {
+  mysql5: `mysql://root:root@127.0.0.1:33065/${databaseName}?${params}`,
+  mysql8: `mysql://root:root@127.0.0.1:33068/${databaseName}?${params}`,
+}
 
 describe('module exports', () => {
   test('default export exists', () => {
@@ -82,324 +85,334 @@ describe('module exports', () => {
   })
 })
 
-describe('initialization', () => {
-  let dbUri: Parameters<typeof MySQLDatabaseEngine>[0]
-  const helpers: Parameters<typeof MySQLDatabaseEngine>[1] = {
-    baseVersion,
-    getAdvisoryLockId,
-    getUserInfo,
-  }
+describe.each(Object.entries(uris))('%s', (_, uri) => {
+  describe('initialization', () => {
+    let dbUri: Parameters<typeof MySQLDatabaseEngine>[0]
+    const helpers: Parameters<typeof MySQLDatabaseEngine>[1] = {
+      baseVersion,
+      getAdvisoryLockId,
+      getUserInfo,
+    }
 
-  beforeEach(() => {
-    dbUri = uri
-    helpers.baseVersion = baseVersion
-    helpers.getAdvisoryLockId = getAdvisoryLockId
-    helpers.getUserInfo = getUserInfo
-  })
-
-  test.each([undefined, null, 0])('throws if uri is %s', (uri) => {
-    expect(() => MySQLDatabaseEngine(uri as any, helpers)).toThrow()
-  })
-
-  test('throws if uri is empty', () => {
-    dbUri = ' '
-    expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
-  })
-
-  describe('helpers validation', () => {
     beforeEach(() => {
+      dbUri = uri
+      helpers.baseVersion = baseVersion
       helpers.getAdvisoryLockId = getAdvisoryLockId
       helpers.getUserInfo = getUserInfo
     })
 
-    test(`throws if getAdvisoryLockId is missing`, () => {
-      delete helpers.getAdvisoryLockId
+    test.each([undefined, null, 0])('throws if uri is %s', (uri) => {
+      expect(() => MySQLDatabaseEngine(uri as any, helpers)).toThrow()
+    })
+
+    test('throws if uri is empty', () => {
+      dbUri = ' '
       expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
     })
 
-    test(`throws if getAdvisoryLockId is not function`, () => {
-      helpers.getAdvisoryLockId = '' as any
-      expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
-      helpers.getAdvisoryLockId = null as any
-      expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
-    })
+    describe('helpers validation', () => {
+      beforeEach(() => {
+        helpers.getAdvisoryLockId = getAdvisoryLockId
+        helpers.getUserInfo = getUserInfo
+      })
 
-    test(`throws if getUserInfo is missing`, () => {
-      delete helpers.getUserInfo
-      expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
-    })
+      test(`throws if getAdvisoryLockId is missing`, () => {
+        delete helpers.getAdvisoryLockId
+        expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
+      })
 
-    test(`throws if getUserInfo is not function`, () => {
-      helpers.getUserInfo = '' as any
-      expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
-      helpers.getUserInfo = null as any
-      expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
-    })
-  })
-})
+      test(`throws if getAdvisoryLockId is not function`, () => {
+        helpers.getAdvisoryLockId = '' as any
+        expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
+        helpers.getAdvisoryLockId = null as any
+        expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
+      })
 
-describe('methods: {open,close}', () => {
-  let connection: Connection
+      test(`throws if getUserInfo is missing`, () => {
+        delete helpers.getUserInfo
+        expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
+      })
 
-  let engine: ReturnType<typeof MySQLDatabaseEngine>
-
-  beforeAll(async () => {
-    const { databaseConfig } = getConfig(uri)
-
-    connection = createConnection(databaseConfig)
-
-    await runQuery(connection, 'DROP TABLE IF EXISTS ??;', [tableName])
-  })
-
-  afterAll(() => {
-    connection.destroy()
-  })
-
-  beforeEach(() => {
-    engine = MySQLDatabaseEngine(uri, {
-      baseVersion,
-      getAdvisoryLockId,
-      getUserInfo,
+      test(`throws if getUserInfo is not function`, () => {
+        helpers.getUserInfo = '' as any
+        expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
+        helpers.getUserInfo = null as any
+        expect(() => MySQLDatabaseEngine(dbUri, helpers)).toThrow()
+      })
     })
   })
 
-  let recordColumnCount: number
+  describe('methods: {open,close}', () => {
+    let connection: Connection
 
-  test('can open & close (first run)', async () => {
-    recordColumnCount = await getTableColumnCount(
-      connection,
-      tableName,
-      'synor'
-    )
+    let engine: ReturnType<typeof MySQLDatabaseEngine>
 
-    expect(recordColumnCount).toBe(0)
+    beforeAll(async () => {
+      const { databaseConfig } = getConfig(uri)
 
-    await expect(engine.open()).resolves.toBeUndefined()
+      connection = createConnection(databaseConfig)
 
-    recordColumnCount = await getTableColumnCount(
-      connection,
-      tableName,
-      'synor'
-    )
-
-    expect(recordColumnCount).toBeGreaterThan(0)
-
-    await expect(engine.close()).resolves.toBeUndefined()
-  })
-
-  test('can open & close (after first run)', async () => {
-    await expect(
-      getTableColumnCount(connection, tableName, databaseName)
-    ).resolves.toBe(recordColumnCount)
-
-    await expect(engine.open()).resolves.toBeUndefined()
-
-    await expect(
-      getTableColumnCount(connection, tableName, databaseName)
-    ).resolves.toBe(recordColumnCount)
-
-    await expect(engine.close()).resolves.toBeUndefined()
-  })
-})
-
-describe('methods: {lock,unlock}', () => {
-  test('can lock & unlock', async () => {
-    const engine = MySQLDatabaseEngine(uri, {
-      baseVersion,
-      getAdvisoryLockId,
-      getUserInfo,
+      await runQuery(connection, 'DROP TABLE IF EXISTS ??;', [tableName])
     })
 
-    await engine.open()
-
-    await expect(engine.lock()).resolves.toBeUndefined()
-
-    await expect(engine.unlock()).resolves.toBeUndefined()
-
-    await engine.close()
-  })
-
-  test.skip('can not get multiple lock at once', async () => {
-    const engineOne = MySQLDatabaseEngine(uri, {
-      baseVersion,
-      getAdvisoryLockId,
-      getUserInfo,
+    afterAll(() => {
+      connection.destroy()
     })
 
-    const engineTwo = MySQLDatabaseEngine(uri, {
-      baseVersion,
-      getAdvisoryLockId,
-      getUserInfo,
+    beforeEach(() => {
+      engine = MySQLDatabaseEngine(uri, {
+        baseVersion,
+        getAdvisoryLockId,
+        getUserInfo,
+      })
     })
 
-    const callOrder: Array<'lock-1' | 'unlock-1' | 'lock-2' | 'unlock-2'> = []
+    let recordColumnCount: number
 
-    await Promise.all([engineOne.open(), engineTwo.open()])
-
-    await engineOne.lock().then(() => {
-      callOrder.push('lock-1')
-    })
-
-    await Promise.all([
-      engineTwo.lock().then(() => {
-        callOrder.push('lock-2')
-      }),
-      engineOne.unlock().then(() => {
-        callOrder.push('unlock-1')
-      }),
-    ])
-
-    await engineTwo.unlock().then(() => {
-      callOrder.push('unlock-2')
-    })
-
-    expect(callOrder).toEqual(['lock-1', 'unlock-1', 'lock-2', 'unlock-2'])
-
-    await Promise.all([engineOne.close(), engineTwo.close()])
-  })
-
-  test('lock throws if failed to get', async () => {
-    const queries = jest.requireActual('./queries')
-
-    jest.spyOn(queries, 'getQueryStore').mockImplementationOnce((...args) => {
-      const queryStore = queries.getQueryStore(...args)
-      queryStore.getLock = () => Promise.resolve(0)
-      return queryStore
-    })
-
-    const engine = MySQLDatabaseEngine(uri, {
-      baseVersion,
-      getAdvisoryLockId,
-      getUserInfo,
-    })
-
-    await engine.open()
-
-    await expect(engine.lock()).rejects.toThrow()
-
-    await engine.close()
-  })
-
-  test('unlock throws if not locked', async () => {
-    const engine = MySQLDatabaseEngine(uri, {
-      baseVersion,
-      getAdvisoryLockId,
-      getUserInfo,
-    })
-
-    await engine.open()
-
-    await expect(engine.unlock()).rejects.toThrow()
-
-    await engine.close()
-  })
-})
-
-describe('methods', () => {
-  let connection: Connection
-
-  let engine: ReturnType<typeof MySQLDatabaseEngine>
-
-  const OriginalDate = Date
-
-  beforeAll(async () => {
-    global.Date = class extends OriginalDate {
-      constructor() {
-        super('2020-01-01T00:00:00.000Z')
-      }
-    } as typeof global.Date
-
-    const { databaseConfig } = getConfig(uri)
-
-    connection = createConnection(databaseConfig)
-
-    await runQuery(connection, 'DROP TABLE IF EXISTS ??;', [tableName])
-  })
-
-  afterAll(() => {
-    connection.destroy()
-
-    global.Date = OriginalDate
-  })
-
-  beforeEach(async () => {
-    engine = MySQLDatabaseEngine(uri, {
-      baseVersion,
-      getAdvisoryLockId,
-      getUserInfo,
-    })
-
-    await engine.open()
-  })
-
-  afterEach(async () => {
-    await engine.close()
-  })
-
-  test('drop', async () => {
-    await expect(
-      getTableColumnCount(connection, tableName, databaseName)
-    ).resolves.toBeGreaterThan(0)
-    await expect(engine.drop()).resolves.toBeUndefined()
-    await expect(
-      getTableColumnCount(connection, tableName, databaseName)
-    ).resolves.toBe(0)
-  })
-
-  test('run (with body)', async () => {
-    await expect(engine.run(migrationSource['01.do'])).resolves.toBeUndefined()
-    await expect(engine.run(migrationSource['01.undo'])).rejects.toThrow()
-
-    await expect(
-      runQuery(connection, `SELECT * FROM ??;`, [tableName])
-    ).resolves.toMatchSnapshot()
-
-    await engine.drop()
-  })
-
-  test('run (with run)', async () => {
-    await expect(engine.run(migrationSource['02.do'])).resolves.toBeUndefined()
-
-    await expect(
-      runQuery(connection, `SELECT * FROM ??;`, [tableName])
-    ).resolves.toMatchSnapshot()
-
-    await engine.drop()
-  })
-
-  test('repair', async () => {
-    await expect(engine.run(migrationSource['01.do'])).resolves.toBeUndefined()
-    await expect(engine.run(migrationSource['01.undo'])).rejects.toThrow()
-
-    const [record] = await runQuery<any[]>(
-      connection,
-      `SELECT id FROM ?? WHERE version = ? AND type = ?;`,
-      [
+    test('can open & close (first run)', async () => {
+      recordColumnCount = await getTableColumnCount(
+        connection,
         tableName,
-        migrationSource['01.do'].version,
-        migrationSource['01.do'].type,
-      ]
-    )
+        'synor'
+      )
 
-    await expect(
-      engine.repair([
-        { id: record.id, hash: `${migrationSource['01.do'].hash}-repaired` },
-      ])
-    ).resolves.toBeUndefined()
+      expect(recordColumnCount).toBe(0)
 
-    await expect(
-      runQuery(connection, `SELECT * FROM ??;`, [tableName])
-    ).resolves.toMatchSnapshot()
+      await expect(engine.open()).resolves.toBeUndefined()
 
-    await engine.drop()
+      recordColumnCount = await getTableColumnCount(
+        connection,
+        tableName,
+        'synor'
+      )
+
+      expect(recordColumnCount).toBeGreaterThan(0)
+
+      await expect(engine.close()).resolves.toBeUndefined()
+    })
+
+    test('can open & close (after first run)', async () => {
+      await expect(
+        getTableColumnCount(connection, tableName, databaseName)
+      ).resolves.toBe(recordColumnCount)
+
+      await expect(engine.open()).resolves.toBeUndefined()
+
+      await expect(
+        getTableColumnCount(connection, tableName, databaseName)
+      ).resolves.toBe(recordColumnCount)
+
+      await expect(engine.close()).resolves.toBeUndefined()
+    })
   })
 
-  test('records', async () => {
-    await expect(engine.run(migrationSource['01.do'])).resolves.toBeUndefined()
-    await expect(engine.run(migrationSource['01.undo'])).rejects.toThrow()
+  describe('methods: {lock,unlock}', () => {
+    test('can lock & unlock', async () => {
+      const engine = MySQLDatabaseEngine(uri, {
+        baseVersion,
+        getAdvisoryLockId,
+        getUserInfo,
+      })
 
-    await expect(engine.records()).resolves.toMatchSnapshot()
+      await engine.open()
 
-    await engine.drop()
+      await expect(engine.lock()).resolves.toBeUndefined()
+
+      await expect(engine.unlock()).resolves.toBeUndefined()
+
+      await engine.close()
+    })
+
+    test.skip('can not get multiple lock at once', async () => {
+      const engineOne = MySQLDatabaseEngine(uri, {
+        baseVersion,
+        getAdvisoryLockId,
+        getUserInfo,
+      })
+
+      const engineTwo = MySQLDatabaseEngine(uri, {
+        baseVersion,
+        getAdvisoryLockId,
+        getUserInfo,
+      })
+
+      const callOrder: Array<'lock-1' | 'unlock-1' | 'lock-2' | 'unlock-2'> = []
+
+      await Promise.all([engineOne.open(), engineTwo.open()])
+
+      await engineOne.lock().then(() => {
+        callOrder.push('lock-1')
+      })
+
+      await Promise.all([
+        engineTwo.lock().then(() => {
+          callOrder.push('lock-2')
+        }),
+        engineOne.unlock().then(() => {
+          callOrder.push('unlock-1')
+        }),
+      ])
+
+      await engineTwo.unlock().then(() => {
+        callOrder.push('unlock-2')
+      })
+
+      expect(callOrder).toEqual(['lock-1', 'unlock-1', 'lock-2', 'unlock-2'])
+
+      await Promise.all([engineOne.close(), engineTwo.close()])
+    })
+
+    test('lock throws if failed to get', async () => {
+      const queries = jest.requireActual('./queries')
+
+      jest.spyOn(queries, 'getQueryStore').mockImplementationOnce((...args) => {
+        const queryStore = queries.getQueryStore(...args)
+        queryStore.getLock = () => Promise.resolve(0)
+        return queryStore
+      })
+
+      const engine = MySQLDatabaseEngine(uri, {
+        baseVersion,
+        getAdvisoryLockId,
+        getUserInfo,
+      })
+
+      await engine.open()
+
+      await expect(engine.lock()).rejects.toThrow()
+
+      await engine.close()
+    })
+
+    test('unlock throws if not locked', async () => {
+      const engine = MySQLDatabaseEngine(uri, {
+        baseVersion,
+        getAdvisoryLockId,
+        getUserInfo,
+      })
+
+      await engine.open()
+
+      await expect(engine.unlock()).rejects.toThrow()
+
+      await engine.close()
+    })
+  })
+
+  describe('methods', () => {
+    let connection: Connection
+
+    let engine: ReturnType<typeof MySQLDatabaseEngine>
+
+    const OriginalDate = Date
+
+    beforeAll(async () => {
+      global.Date = class extends OriginalDate {
+        constructor() {
+          super('2020-01-01T00:00:00.000Z')
+        }
+      } as typeof global.Date
+
+      const { databaseConfig } = getConfig(uri)
+
+      connection = createConnection(databaseConfig)
+
+      await runQuery(connection, 'DROP TABLE IF EXISTS ??;', [tableName])
+    })
+
+    afterAll(() => {
+      connection.destroy()
+
+      global.Date = OriginalDate
+    })
+
+    beforeEach(async () => {
+      engine = MySQLDatabaseEngine(uri, {
+        baseVersion,
+        getAdvisoryLockId,
+        getUserInfo,
+      })
+
+      await engine.open()
+    })
+
+    afterEach(async () => {
+      await engine.close()
+    })
+
+    test('drop', async () => {
+      await expect(
+        getTableColumnCount(connection, tableName, databaseName)
+      ).resolves.toBeGreaterThan(0)
+      await expect(engine.drop()).resolves.toBeUndefined()
+      await expect(
+        getTableColumnCount(connection, tableName, databaseName)
+      ).resolves.toBe(0)
+    })
+
+    test('run (with body)', async () => {
+      await expect(
+        engine.run(migrationSource['01.do'])
+      ).resolves.toBeUndefined()
+      await expect(engine.run(migrationSource['01.undo'])).rejects.toThrow()
+
+      await expect(
+        runQuery(connection, `SELECT * FROM ??;`, [tableName])
+      ).resolves.toMatchSnapshot()
+
+      await engine.drop()
+    })
+
+    test('run (with run)', async () => {
+      await expect(
+        engine.run(migrationSource['02.do'])
+      ).resolves.toBeUndefined()
+
+      await expect(
+        runQuery(connection, `SELECT * FROM ??;`, [tableName])
+      ).resolves.toMatchSnapshot()
+
+      await engine.drop()
+    })
+
+    test('repair', async () => {
+      await expect(
+        engine.run(migrationSource['01.do'])
+      ).resolves.toBeUndefined()
+      await expect(engine.run(migrationSource['01.undo'])).rejects.toThrow()
+
+      const [record] = await runQuery<any[]>(
+        connection,
+        `SELECT id FROM ?? WHERE version = ? AND type = ?;`,
+        [
+          tableName,
+          migrationSource['01.do'].version,
+          migrationSource['01.do'].type,
+        ]
+      )
+
+      await expect(
+        engine.repair([
+          { id: record.id, hash: `${migrationSource['01.do'].hash}-repaired` },
+        ])
+      ).resolves.toBeUndefined()
+
+      await expect(
+        runQuery(connection, `SELECT * FROM ??;`, [tableName])
+      ).resolves.toMatchSnapshot()
+
+      await engine.drop()
+    })
+
+    test('records', async () => {
+      await expect(
+        engine.run(migrationSource['01.do'])
+      ).resolves.toBeUndefined()
+      await expect(engine.run(migrationSource['01.undo'])).rejects.toThrow()
+
+      await expect(engine.records()).resolves.toMatchSnapshot()
+
+      await engine.drop()
+    })
   })
 })

--- a/packages/database-mysql/src/index.ts
+++ b/packages/database-mysql/src/index.ts
@@ -1,12 +1,12 @@
 import { SynorError } from '@synor/core'
-import { createConnection } from 'mysql'
+import { createConnection } from 'mysql2'
 import { performance } from 'perf_hooks'
 import { getQueryStore } from './queries'
 import { ensureMigrationRecordTable } from './utils/ensure-migration-record-table'
 import { getConfig } from './utils/get-config'
 import { runQuery } from './utils/run-query'
 
-type Connection = import('mysql').Connection
+type Connection = import('mysql2').Connection
 type DatabaseEngine = import('@synor/core').DatabaseEngine
 type DatabaseEngineFactory = import('@synor/core').DatabaseEngineFactory
 type MigrationSource = import('@synor/core').MigrationSource

--- a/packages/database-mysql/src/queries.ts
+++ b/packages/database-mysql/src/queries.ts
@@ -176,7 +176,7 @@ export function getQueryStore(
 
   const getTableNames = QueryRunner<Array<{ table_name: string }>, string[]>(
     `
-      SELECT table_name
+      SELECT table_name as table_name
       FROM information_schema.tables
       WHERE table_schema = ?
     `,

--- a/packages/database-mysql/src/queries.ts
+++ b/packages/database-mysql/src/queries.ts
@@ -3,7 +3,7 @@
 import { promisify } from 'util'
 import { runQuery } from './utils/run-query'
 
-type Connection = import('mysql').Connection
+type Connection = import('mysql2').Connection
 type MigrationRecord = import('@synor/core').MigrationRecord
 type QueryValue = import('./utils/run-query').QueryValue
 
@@ -57,9 +57,7 @@ export function getQueryStore(
     advisoryLockId,
   }: QueryStoreOptions
 ): QueryStore {
-  const openConnection = promisify<void>((callback) =>
-    connection.connect(callback)
-  )
+  const openConnection = async (): Promise<void> => {}
 
   const closeConnection = promisify<void>((callback) =>
     connection.end((err) => callback(err))

--- a/packages/database-mysql/src/utils/__snapshots__/run-query.test.ts.snap
+++ b/packages/database-mysql/src/utils/__snapshots__/run-query.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`utils:runQuery can execute query 1`] = `
+exports[`for mysql5 utils:runQuery can execute query 1`] = `
 Array [
   Object {
     "1": 1,
@@ -8,7 +8,23 @@ Array [
 ]
 `;
 
-exports[`utils:runQuery can substitute values in query 1`] = `
+exports[`for mysql5 utils:runQuery can substitute values in query 1`] = `
+Array [
+  Object {
+    "1": 1,
+  },
+]
+`;
+
+exports[`for mysql8 utils:runQuery can execute query 1`] = `
+Array [
+  Object {
+    "1": 1,
+  },
+]
+`;
+
+exports[`for mysql8 utils:runQuery can substitute values in query 1`] = `
 Array [
   Object {
     "1": 1,

--- a/packages/database-mysql/src/utils/__snapshots__/run-query.test.ts.snap
+++ b/packages/database-mysql/src/utils/__snapshots__/run-query.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`utils:runQuery can execute query 1`] = `
 Array [
-  RowDataPacket {
+  Object {
     "1": 1,
   },
 ]
@@ -10,7 +10,7 @@ Array [
 
 exports[`utils:runQuery can substitute values in query 1`] = `
 Array [
-  RowDataPacket {
+  Object {
     "1": 1,
   },
 ]

--- a/packages/database-mysql/src/utils/get-config.test.ts
+++ b/packages/database-mysql/src/utils/get-config.test.ts
@@ -66,7 +66,7 @@ describe('utils:getMySQLConfig', () => {
     ])(`reads ssl.%s file content`, (key, content) => {
       jest
         .spyOn(fs, 'readFileSync')
-        .mockImplementationOnce((v: any) => Buffer.from(`CONTENT:${v}`))
+        .mockImplementationOnce((v) => Buffer.from(`CONTENT:${String(v)}`))
 
       const ssl = { [key]: content }
       uri = `${uri}?ssl=${encodeURIComponent(JSON.stringify(ssl))}`

--- a/packages/database-mysql/src/utils/get-config.ts
+++ b/packages/database-mysql/src/utils/get-config.ts
@@ -3,13 +3,15 @@ import { ConnectionString } from 'connection-string'
 import { readFileSync } from 'fs'
 import { resolve as resolvePath } from 'path'
 
-type ConnectionConfig = import('mysql').ConnectionConfig
+type ConnectionOptions = import('mysql2').ConnectionOptions
 type TLSConnectionOptions = import('tls').ConnectionOptions
 
 type SSLConfig = Pick<
   TLSConnectionOptions,
-  'ca' | 'cert' | 'ciphers' | 'key' | 'passphrase' | 'rejectUnauthorized'
->
+  'ca' | 'cert' | 'ciphers' | 'passphrase' | 'rejectUnauthorized'
+> & {
+  key?: string
+}
 
 type SSLParams = Pick<
   SSLConfig,
@@ -20,9 +22,9 @@ type SSLParams = Pick<
   cert?: string
 }
 
-type MySQLDatabaseConfig = Required<Pick<ConnectionConfig, 'database'>> &
+type MySQLDatabaseConfig = Required<Pick<ConnectionOptions, 'database'>> &
   Pick<
-    ConnectionConfig,
+    ConnectionOptions,
     'host' | 'port' | 'user' | 'password' | 'multipleStatements' | 'ssl'
   >
 
@@ -59,7 +61,7 @@ export function getConfig(
       throw new Error(`[URI] unsupported: protocol(${protocol})!`)
     }
 
-    const database = path && path[0]
+    const database = path?.[0]
 
     if (!database) {
       throw new Error('[URI] missing: database!')
@@ -86,7 +88,7 @@ export function getConfig(
           ssl.cert = readFileSync(resolvePath(sslParams.cert))
         }
         if (sslParams.key) {
-          ssl.key = readFileSync(resolvePath(sslParams.key))
+          ssl.key = readFileSync(resolvePath(sslParams.key)).toString()
         }
       } catch (_) {
         ssl = sslRaw

--- a/packages/database-mysql/src/utils/run-query.test.ts
+++ b/packages/database-mysql/src/utils/run-query.test.ts
@@ -1,7 +1,7 @@
-import { createConnection } from 'mysql'
+import { createConnection } from 'mysql2'
 import { runQuery } from './run-query'
 
-type Connection = import('mysql').Connection
+type Connection = import('mysql2').Connection
 
 const uri = 'mysql://root:root@127.0.0.1:3306/synor'
 

--- a/packages/database-mysql/src/utils/run-query.test.ts
+++ b/packages/database-mysql/src/utils/run-query.test.ts
@@ -3,30 +3,35 @@ import { runQuery } from './run-query'
 
 type Connection = import('mysql2').Connection
 
-const uri = 'mysql://root:root@127.0.0.1:3306/synor'
+const uris = {
+  mysql5: `mysql://root:root@127.0.0.1:33065/synor`,
+  mysql8: `mysql://root:root@127.0.0.1:33068/synor`,
+}
 
-describe('utils:runQuery', () => {
-  let connection: Connection
+describe.each(Object.entries(uris))('for %s', (_, uri) => {
+  describe('utils:runQuery', () => {
+    let connection: Connection
 
-  beforeAll(() => {
-    connection = createConnection(uri)
-  })
+    beforeAll(() => {
+      connection = createConnection(uri)
+    })
 
-  afterAll(() => {
-    connection.destroy()
-  })
+    afterAll(() => {
+      connection.destroy()
+    })
 
-  test('can execute query', async () => {
-    await expect(runQuery(connection, 'SELECT 1;')).resolves.toMatchSnapshot()
-  })
+    test('can execute query', async () => {
+      await expect(runQuery(connection, 'SELECT 1;')).resolves.toMatchSnapshot()
+    })
 
-  test('can substitute values in query', async () => {
-    await expect(
-      runQuery(connection, 'SELECT ?;', [1])
-    ).resolves.toMatchSnapshot()
-  })
+    test('can substitute values in query', async () => {
+      await expect(
+        runQuery(connection, 'SELECT ?;', [1])
+      ).resolves.toMatchSnapshot()
+    })
 
-  test('throws if malformed query', async () => {
-    await expect(runQuery(connection, 'SELEC 1;')).rejects.toThrow()
+    test('throws if malformed query', async () => {
+      await expect(runQuery(connection, 'SELEC 1;')).rejects.toThrow()
+    })
   })
 })

--- a/packages/database-mysql/src/utils/run-query.ts
+++ b/packages/database-mysql/src/utils/run-query.ts
@@ -1,4 +1,4 @@
-type Connection = import('mysql').Connection
+type Connection = import('mysql2').Connection
 
 export type QueryValue = boolean | number | string | Date
 
@@ -14,7 +14,7 @@ export async function runQuery<T = any>(
         return
       }
 
-      resolve(results)
+      resolve((results as unknown) as T)
     })
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2763,13 +2763,6 @@
     "@types/bson" "*"
     "@types/node" "*"
 
-"@types/mysql@^2":
-  version "2.15.15"
-  resolved "https://registry.yarnpkg.com/@types/mysql/-/mysql-2.15.15.tgz#af2223d2841091a5a819eabee6dff19567f1cf1f"
-  integrity sha512-1GJnq7RwuFPRicMHdT53vza5v39nep9OKIbozxNUpFXP04CydcdWrqpZQ+MlVdlLFCisWnnt09xughajjWpFsw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@>= 8":
   version "13.13.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.0.tgz#30d2d09f623fe32cde9cb582c7a6eda2788ce4a8"
@@ -3390,11 +3383,6 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
-
-bignumber.js@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
-  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
 bili@^5.0.5:
   version "5.0.5"
@@ -4888,6 +4876,11 @@ denque@^1.4.1:
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
   integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
+denque@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
+
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
@@ -6033,6 +6026,13 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+generate-function@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
+  dependencies:
+    is-property "^1.0.2"
+
 generic-names@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-2.0.1.tgz#f8a378ead2ccaa7a34f0317b05554832ae41b872"
@@ -6571,6 +6571,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-replace-symbols@1.1.0, icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -7065,6 +7072,11 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
+is-property@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==
 
 is-reference@^1.1.2:
   version "1.2.1"
@@ -8079,6 +8091,11 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
 longest@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-2.0.1.tgz#781e183296aa94f6d4d916dc335d0d17aefa23f8"
@@ -8099,12 +8116,27 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
+lru-cache@^4.1.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -8530,15 +8562,19 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-mysql@^2:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/mysql/-/mysql-2.18.1.tgz#2254143855c5a8c73825e4522baf2ea021766717"
-  integrity sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==
+mysql2@^2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/mysql2/-/mysql2-2.3.3.tgz#944f3deca4b16629052ff8614fbf89d5552545a0"
+  integrity sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==
   dependencies:
-    bignumber.js "9.0.0"
-    readable-stream "2.3.7"
-    safe-buffer "5.1.2"
-    sqlstring "2.3.1"
+    denque "^2.0.1"
+    generate-function "^2.3.1"
+    iconv-lite "^0.6.3"
+    long "^4.0.0"
+    lru-cache "^6.0.0"
+    named-placeholders "^1.1.2"
+    seq-queue "^0.0.5"
+    sqlstring "^2.3.2"
 
 mz@^2.5.0:
   version "2.7.0"
@@ -8548,6 +8584,13 @@ mz@^2.5.0:
     any-promise "^1.0.0"
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
+
+named-placeholders@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/named-placeholders/-/named-placeholders-1.1.2.tgz#ceb1fbff50b6b33492b5cf214ccf5e39cef3d0e8"
+  integrity sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==
+  dependencies:
+    lru-cache "^4.1.3"
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -9911,6 +9954,11 @@ protoduck@^5.0.1:
   dependencies:
     genfun "^5.0.0"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
+
 psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
@@ -10117,7 +10165,7 @@ read@1, read@~1.0.1:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@2.3.7, readable-stream@^2.0.0, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -10634,11 +10682,6 @@ rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.5:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
@@ -10648,6 +10691,11 @@ safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-identifier@^0.4.1:
   version "0.4.1"
@@ -10661,7 +10709,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -10739,6 +10787,11 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+seq-queue@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/seq-queue/-/seq-queue-0.0.5.tgz#d56812e1c017a6e4e7c3e3a37a1da6d78dd3c93e"
+  integrity sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==
 
 serialize-javascript@^3.0.0:
   version "3.1.0"
@@ -11056,10 +11109,10 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sqlstring@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.1.tgz#475393ff9e91479aea62dcaf0ca3d14983a7fb40"
-  integrity sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=
+sqlstring@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.3.tgz#2ddc21f03bce2c387ed60680e739922c65751d0c"
+  integrity sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -12302,10 +12355,20 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
+
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.7.2:
   version "1.9.1"


### PR DESCRIPTION
Switch to [`mysql2`](https://github.com/sidorares/node-mysql2).

Because [`mysql`](https://github.com/mysqljs/mysql) does not support MySQL8 auth plugin (e.g. `caching_sha2_password`).
Issues: https://github.com/mysqljs/mysql/issues?q=is%3Aissue+ER_NOT_SUPPORTED_AUTH_MODE+is%3Aopen.

